### PR TITLE
Add AppIcons from previous additional pairings

### DIFF
--- a/app/src/main/res/xml/theme_resources.xml
+++ b/app/src/main/res/xml/theme_resources.xml
@@ -6635,4 +6635,6 @@
 	<AppIcon name="com.hiddenramblings.tagmo/com.hiddenramblings.tagmo.MainActivity_" image="tagmo" />
 	<AppIcon name="com.raildeliverygroup.railcard/com.raildeliverygroup.railcard.Launcher" image="railcard" />
 	<AppIcon name="org.stjr.srb2/org.stjr.srb2.SRB2Game" image="sonic_robo_blast_2" />
+	<AppIcon name="com.sega.soniccd/com.sega.soniccd.SonicCDActivity" drawable="sonic_cd_classic" />
+	<AppIcon name="com.braksoftware.HumanJapanese/com.braksoftware.HumanJapaneseCore.SplashActivity" drawable="human_japanese" />
 </Theme>


### PR DESCRIPTION
These are additional pairings I added before to apps but didn't add entries to `theme_resources.xml`.