### PR TITLE
Fix Shonen Jump Plus link

### DIFF
--- a/app/src/main/assets/appfilter.xml
+++ b/app/src/main/assets/appfilter.xml
@@ -13877,7 +13877,7 @@
 	<item component="ComponentInfo{jp.co.duskin.misdocardapps/jp.co.duskin.misdocardapps.MainActivity}" drawable="mister_donut" />
 	<item component="ComponentInfo{info.shiosyakeyakini.miria/info.shiosyakeyakini.miria.MainActivity}" drawable="miria" />
 	<item component="ComponentInfo{jp.dreambrain.adiorama/com.cognizantorderserv.kfcindiadroid.MainActivity}" drawable="kfc" />
-	<item component="ComponentInfo{com.access_company.android.sh_jumpplus/giga.app.MainActivity}" drawable="jump_plus" />
+	<item component="ComponentInfo{com.access_company.android.sh_jumpplus/giga.app.MainActivity}" drawable="shonen_jump_plus" />
 	<item component="ComponentInfo{at.techbee.jtx/at.techbee.jtx.MainActivity2}" drawable="jtx" />
 	<item component="ComponentInfo{com.android.gpstest.osmdroid/com.android.gpstest.ui.MainActivity}" drawable="gpstest" />
 	<item component="ComponentInfo{io.chthonic.gog.client/io.chthonic.gog.client.ui.activity.MainActivity}" drawable="gog" />

--- a/app/src/main/assets/drawable.xml
+++ b/app/src/main/assets/drawable.xml
@@ -18,7 +18,6 @@
 	<item drawable="immich" />
 	<item drawable="json_list" />
 	<item drawable="jtx" />
-	<item drawable="jump_plus" />
 	<item drawable="keepass_fidelty" />
 	<item drawable="keypass" />
 	<item drawable="local_material_notes" />
@@ -5295,7 +5294,6 @@
 	<item drawable="juicessh" />
 	<item drawable="julians_editor" />
 	<item drawable="jumbo" />
-	<item drawable="jump_plus" />
 	<item drawable="junior_hockey_league" />
 	<item drawable="juno" />
 	<item drawable="jupiter" />

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -13877,7 +13877,7 @@
 	<item component="ComponentInfo{jp.co.duskin.misdocardapps/jp.co.duskin.misdocardapps.MainActivity}" drawable="mister_donut" />
 	<item component="ComponentInfo{info.shiosyakeyakini.miria/info.shiosyakeyakini.miria.MainActivity}" drawable="miria" />
 	<item component="ComponentInfo{jp.dreambrain.adiorama/com.cognizantorderserv.kfcindiadroid.MainActivity}" drawable="kfc" />
-	<item component="ComponentInfo{com.access_company.android.sh_jumpplus/giga.app.MainActivity}" drawable="jump_plus" />
+	<item component="ComponentInfo{com.access_company.android.sh_jumpplus/giga.app.MainActivity}" drawable="shonen_jump_plus" />
 	<item component="ComponentInfo{at.techbee.jtx/at.techbee.jtx.MainActivity2}" drawable="jtx" />
 	<item component="ComponentInfo{com.android.gpstest.osmdroid/com.android.gpstest.ui.MainActivity}" drawable="gpstest" />
 	<item component="ComponentInfo{io.chthonic.gog.client/io.chthonic.gog.client.ui.activity.MainActivity}" drawable="gog" />

--- a/app/src/main/res/xml/drawable.xml
+++ b/app/src/main/res/xml/drawable.xml
@@ -18,7 +18,6 @@
 	<item drawable="immich" />
 	<item drawable="json_list" />
 	<item drawable="jtx" />
-	<item drawable="jump_plus" />
 	<item drawable="keepass_fidelty" />
 	<item drawable="keypass" />
 	<item drawable="local_material_notes" />
@@ -5295,7 +5294,6 @@
 	<item drawable="juicessh" />
 	<item drawable="julians_editor" />
 	<item drawable="jumbo" />
-	<item drawable="jump_plus" />
 	<item drawable="junior_hockey_league" />
 	<item drawable="juno" />
 	<item drawable="jupiter" />


### PR DESCRIPTION
In #847, I missed that `jump_plus` was renamed to `shonen_jump_plus` because I was looking under the `resources/vectors` directory.