### PR TITLE
Match up existing icons to the Netflix game library

### DIFF
--- a/resources/new_icons.yaml
+++ b/resources/new_icons.yaml
@@ -8,3 +8,27 @@
 #
 # new_icon_2_alt_1: {}
 #
+
+bloons_td_six:
+  - com.netflix.NGP.BloonsTDSix/com.unity3d.player.UnityPlayerActivity
+
+world_of_goo:
+  - com.netflix.NGP.WorldofGooHD/com.twodboy.wog.MainActivity
+
+game_dev_tycoon:
+  - com.netflix.NGP.GameDevTycoon/com.unity3d.player.UnityPlayerActivity
+
+gta_iii:
+  - com.netflix.NGP.GTAIIIDefinitiveEdition/com.epicgames.ue4.GameActivity
+
+gta_vice_city:
+  - com.netflix.NGP.GTAViceCityDefinitiveEdition/com.epicgames.ue4.GameActivity
+
+gta_san_andreas:
+  - com.netflix.NGP.GTASanAndreasDefinitiveEdition/com.epicgames.ue4.GameActivity
+
+dead_cells:
+  - com.netflix.NGP.DeadCellsReturnToCastlevania/com.playdigious.deadcells.mobile.DeadCellsLoading
+
+cats_and_soup:
+  - com.netflix.NGP.CatsSoup/com.unity3d.player.UnityPlayerActivity

--- a/resources/requests.txt
+++ b/resources/requests.txt
@@ -140,12 +140,6 @@ https://play.google.com/store/apps/details?id=com.tfuerholzer.darkmodewallpaper
 Requested 5 times
 Last requested 1708417299.0
 	
-NETFLIX
-com.netflix.NGP.BloonsTDSix/com.unity3d.player.UnityPlayerActivity
-https://play.google.com/store/apps/details?id=com.netflix.NGP.BloonsTDSix
-Requested 5 times
-Last requested 1708187579.0
-	
 سينمانا
 com.shabakaty.cinemana/com.shabakaty.cinemana.ui.splash.SplashActivity
 https://play.google.com/store/apps/details?id=com.shabakaty.cinemana
@@ -4435,12 +4429,6 @@ com.geode.launcher/com.geode.launcher.MainActivity
 https://play.google.com/store/apps/details?id=com.geode.launcher
 Requested 2 times
 Last requested 1711187415.0
-	
-Edition
-com.netflix.NGP.DeadCellsReturnToCastlevania/com.playdigious.deadcells.mobile.DeadCellsLoading
-https://play.google.com/store/apps/details?id=com.netflix.NGP.DeadCellsReturnToCastlevania
-Requested 2 times
-Last requested 1710965264.0
 	
 KKBOX
 com.skysoft.kkbox.android/com.skysoft.kkbox.android.HomeActivity
@@ -16705,12 +16693,6 @@ com.nest.sttm/com.nest.sttm.splash.SplashActivity
 https://play.google.com/store/apps/details?id=com.nest.sttm
 Requested 1 times
 Last requested 1704904922.0
-	
-SA
-com.netflix.NGP.GTASanAndreasDefinitiveEdition/com.epicgames.ue4.GameActivity
-https://play.google.com/store/apps/details?id=com.netflix.NGP.GTASanAndreasDefinitiveEdition
-Requested 1 times
-Last requested 1704641302.0
 	
 Partner
 runner.dunzo.com.dunzo_runner/runner.dunzo.com.dunzoRunner.activities.MainActivity


### PR DESCRIPTION
Noticed a few requests where the Netflix version of existing games, so updated any matching games I could find. This includes:
* Bloons TD 6
* World of Goo
* Game Dev Tycoon
* GTA 3
* GTA Vice City
* GTA San Andreas
* Dead Cells
* Cats & Soup