### PR TITLE
Enable gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx2048M
 org.gradle.parallel=true


### PR DESCRIPTION
Enable the Gradle [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) to improve build performance in subsequent builds

Somewhat anecdotal, but for me it appears to shave quite a bit of time off subsequent rebuilds :)