### PR TITLE
feat: support starbucks, uniqlo vn region icons

### DIFF
--- a/app/src/main/assets/appfilter.xml
+++ b/app/src/main/assets/appfilter.xml
@@ -18831,4 +18831,6 @@
 	<item component="ComponentInfo{zombie.survival.craft.z/ru.kv3dunityext.permissions.MainActivity}" drawable="last_day_on_earth_survival" />
 	<item component="ComponentInfo{zte.com.cn.alarmclock/zte.com.cn.alarmclock.activity.AlarmClockActivity}" drawable="clock" />
 	<item component="ComponentInfo{zte.com.cn.filer/zte.com.cn.filer.FileMgrActivity}" drawable="file_manager" />
+	<item component="ComponentInfo{com.starbucks.vn/com.starbucks.vn.TrampolineActivity}" drawable="starbucks" />
+	<item component="ComponentInfo{com.uniqlo.vn.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" />
 </resources>

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -18831,4 +18831,6 @@
 	<item component="ComponentInfo{zombie.survival.craft.z/ru.kv3dunityext.permissions.MainActivity}" drawable="last_day_on_earth_survival" />
 	<item component="ComponentInfo{zte.com.cn.alarmclock/zte.com.cn.alarmclock.activity.AlarmClockActivity}" drawable="clock" />
 	<item component="ComponentInfo{zte.com.cn.filer/zte.com.cn.filer.FileMgrActivity}" drawable="file_manager" />
+	<item component="ComponentInfo{com.starbucks.vn/com.starbucks.vn.TrampolineActivity}" drawable="starbucks" />
+	<item component="ComponentInfo{com.uniqlo.vn.catalogue/com.uniqlo.ja.catalogue.view.mobile.home.DummyLauncherActivity}" drawable="uniqlo" />
 </resources>


### PR DESCRIPTION
Add support for vn region apps:

- com.starbucks.vn (https://play.google.com/store/apps/details?id=com.starbucks.vn)
- com.uniqlo.vn.catalogue (https://play.google.com/store/apps/details?id=com.uniqlo.vn.catalogue)

I add starbucks previously in https://github.com/Delta-Icons/android/pull/1358 but it seems like starbucks has changed activity name (`com.starbucks.vn.MainActivity` -> `com.starbucks.vn.TrampolineActivity`)

I use https://github.com/Kaiserdragon2/IconRequest to extract app name/activity