### PR TITLE
Enable Yasan Launcher support

### DIFF
--- a/app/src/main/res/values/launchers.xml
+++ b/app/src/main/res/values/launchers.xml
@@ -48,6 +48,7 @@
         <item>square</item>
         <!--<item>v</item>-->
         <item>tinybit</item>
+        <item>yasan</item>
         <item>zenui</item>
         <!--<item>zero</item>-->
     </string-array>


### PR DESCRIPTION
Yasan Launcher support was added to Candybar FOSS in https://github.com/Donnnno/candybar-foss/pull/26, but also needs to be updated in this project to be accessible to Delta icon users.